### PR TITLE
Add helper function for MacOS backends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.2"
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -1,6 +1,7 @@
 module Alert
 using Base64
 using Dates
+using Logging
 using Printf
 using REPL
 
@@ -212,6 +213,52 @@ function init_alertREPL()
     if VERSION >= v"1.5"
         pushfirst!(REPL.repl_ast_transforms, with_repl_alert)
     end
+end
+
+"""
+
+    apple_backend(title="Julia", subtitle="", sound="", test=false)
+
+Helper function to define a Script Editor backend for MacOS systems.
+
+# Arguments
+- `title::AbstractString="Julia"`: Notification title
+- `subtitle::AbstractString=""`: Notification subtitle
+- `sound::AbstractString=""`: Notification sound
+- `test::Bool=false`: Display a sample notification when initializing
+
+# Examples
+```jldoctest
+julia> mybackend = Alert.apple_backend(title="𝒥𝓊𝓁𝒾𝒶", subtitle="Alert.jl", sound="Crystal");
+
+julia> Alert.set_alert_backend!(mybackend);
+
+julia> alert("From a fancy backend!")
+```
+"""
+function apple_backend(;
+    title::AbstractString="Julia",
+    subtitle::AbstractString="",
+    sound::AbstractString="",
+    test::Bool=false
+)
+    @static if !Sys.isapple()
+        @warn "You are attempting to set a MacOS backend on a different system!"
+    end
+
+    options = ""
+    options = length(title) > 0 ? options * " with title \"$title\"" : options
+    options = length(subtitle) > 0 ? options * " subtitle \"$subtitle\"" : options
+    options = length(sound) > 0 ? options * " sound name \"$sound\"" : options
+
+    @debug "Current command" cmd=`osascript -e 'display notification "'message'"'$options''`
+
+    if test
+        testmsg = "Your notifications will now look like this!"
+        run(`osascript -e 'display notification "'$testmsg'"'$options''`)
+    end
+
+    return message -> run(`osascript -e 'display notification "'$message'"'$options''`)
 end
 
 end


### PR DESCRIPTION
This PR adds a helper function for users to define custom backends on MacOS systems. It extends the current Script Editor backend by allowing for customizable titles, subtitles, and notification sounds. The example from the function documentation:

```julia-repl
julia> mybackend = Alert.apple_backend(title="𝒥𝓊𝓁𝒾𝒶", subtitle="Alert.jl", sound="Crystal");

julia> Alert.set_alert_backend!(mybackend);

julia> alert("From a fancy backend!")
```